### PR TITLE
nnoremap instead of map

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,10 @@
+Fork
+----
+Uses `nnoremap` instead of `map` to avoid conflicts.
+
+Original README
+---------------
+
 This is a mirror of http://www.vim.org/scripts/script.php?script_id=593
 
 This plugin defines key mappings to quickly make the GUI font larger or

--- a/plugin/guifont++.vim
+++ b/plugin/guifont++.vim
@@ -127,7 +127,7 @@ fun! s:SetOriginalFont()
     endif
 endfun
 
-let s:ms = "map <silent> "
+let s:ms = "nnoremap <silent> "
 exe s:ms . s:guifontpp_smaller_font_map  . " :call <SID>SetSmallerFont()<CR>"
 exe s:ms . s:guifontpp_larger_font_map   . " :call <SID>SetLargerFont()<CR>"
 exe s:ms . s:guifontpp_original_font_map . " :call <SID>SetOriginalFont()<CR>"


### PR DESCRIPTION
map causes issues if, for example, you swap `;` and `:`
