### PR TITLE
Allow decimal separator in font-size

### DIFF
--- a/plugin/guifont++.vim
+++ b/plugin/guifont++.vim
@@ -70,7 +70,7 @@ if exists("g:guifontpp_original_font_map")
     let s:guifontpp_original_font_map = g:guifontpp_original_font_map
 endif
 
-let s:decimalpat = '[1-9][0-9]*'
+let s:decimalpat = '[1-9][0-9]*\.\?[0-9]\?'
 let s:fontpat_unix = '^\(\(-[^-]\+\)\{6}-\)\(' . s:decimalpat . '\)'
 let s:fontpat_win32 = '\(:h\)\(' . s:decimalpat . '\)\(:\|,\|$\)'
 


### PR DESCRIPTION
Example on Windows: `set guifont=Consolas:h10.5:cANSI`

Prior to this change the font size of `10.5` would cause the error "Cannot match your 'guifont' to a known pattern".

I tested this only on Windows gVim 9.0.